### PR TITLE
fix bug: core/gis.py: use non-existent topo_valid_mask key from nc.variables

### DIFF
--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -758,7 +758,6 @@ def glacier_masks(gdir):
         v[:] = glacier_ext
 
         dem = nc.variables['topo'][:]
-        valid_mask = nc.variables['topo_valid_mask'][:]
 
         # Last sanity check based on the masked dem
         tmp_max = np.max(dem[np.where(glacier_mask == 1)])


### PR DESCRIPTION
solution: delete the related line

<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->
